### PR TITLE
HOPSWORKS-745: Make Spark compatible with HopsHive

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,7 +8,7 @@ default['livy']['url']                     = "#{node['download_url']}/livy-#{nod
 default['livy']['port']                    = "8998"
 default['livy']['dir']                     = node['install']['dir'].empty? ? "/srv" : node['install']['dir']
 default['livy']['home']                    = node['livy']['dir'] + "/livy-" + node['livy']['version']
-default['livy']['base_dir']                = node['livy']['dir'] + "/livy" 
+default['livy']['base_dir']                = node['livy']['dir'] + "/livy"
 default['livy']['keystore']                = "#{node['kagent']['certs_dir']}/keystores/#{node['hostname']}__kstore.jks"
 default['livy']['keystore_password']       = node['hopsworks']['master']['password']
 

--- a/templates/default/livy.conf.erb
+++ b/templates/default/livy.conf.erb
@@ -52,3 +52,4 @@ livy.server.recovery.state-store=filesystem
 
 livy.server.recovery.state-store.url = file://<%= node['livy']['base_dir'] %>/logs
 
+livy.repl.enableHiveContext = true


### PR DESCRIPTION
enable Hive in spark sessions created by livy

Fix version of snurran to use this fix: https://github.com/logicalclocks/incubator-livy/pull/3

Tests: https://github.com/logicalclocks/hops-testing/pull/223