### PR TITLE
[HOPSWORKS-453] Configure Livy to use local binaries

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ include_attribute "kagent"
 default['livy']['user']                    = node['install']['user'].empty? ? "livy" : node['install']['user']
 default['livy']['group']                   = node['install']['user'].empty? ? node['hadoop_spark']['group'] : node['install']['user']
 
-default['livy']['version']                 = "0.6.1.0-bin"
+default['livy']['version']                 = "0.6.1.1-bin"
 default['livy']['url']                     = "#{node['download_url']}/apache-livy-#{node['livy']['version']}.zip"
 default['livy']['port']                    = "8998"
 default['livy']['dir']                     = node['install']['dir'].empty? ? "/srv" : node['install']['dir']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -76,6 +76,25 @@ bash 'extract-livy' do
      not_if { ::File.exists?( "#{livy_downloaded}" ) }
 end
 
+bash 'link-jars' do
+        user "root"
+        group node['livy']['group']
+        code <<-EOH
+                rm -f #{node['livy']['base_dir']}/rsc-jars/livy-api.jar
+                rm -f #{node['livy']['base_dir']}/rsc-jars/livy-rsc.jar
+                rm -f #{node['livy']['base_dir']}/rsc-jars/netty-all.jar
+                ln -s #{node['livy']['base_dir']}/rsc-jars/livy-api-*.jar #{node['livy']['base_dir']}/rsc-jars/livy-api.jar
+                ln -s #{node['livy']['base_dir']}/rsc-jars/livy-rsc-*jar #{node['livy']['base_dir']}/rsc-jars/livy-rsc.jar
+                ln -s #{node['livy']['base_dir']}/rsc-jars/netty-all-*.jar #{node['livy']['base_dir']}/rsc-jars/netty-all.jar
+                rm -f #{node['livy']['base_dir']}/repl_2.11-jars/commons-codec.jar
+                rm -f #{node['livy']['base_dir']}/repl_2.11-jars/livy-core.jar
+                rm -f #{node['livy']['base_dir']}/repl_2.11-jars/livy-repl.jar
+                ln -s #{node['livy']['base_dir']}/repl_2.11-jars/commons-codec-*.jar #{node['livy']['base_dir']}/repl_2.11-jars/commons-codec.jar
+                ln -s #{node['livy']['base_dir']}/repl_2.11-jars/livy-core_*.jar #{node['livy']['base_dir']}/repl_2.11-jars/livy-core.jar
+                ln -s #{node['livy']['base_dir']}/repl_2.11-jars/livy-repl_*.jar #{node['livy']['base_dir']}/repl_2.11-jars/livy-repl.jar
+        EOH
+end
+
 directory "#{node['livy']['home']}/logs" do
   owner node['livy']['user']
   group node['livy']['group']

--- a/templates/default/livy.conf.erb
+++ b/templates/default/livy.conf.erb
@@ -26,6 +26,31 @@ livy.server.csrf-protection.enabled = false
 # Comma-separated list of Livy RSC jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
 # time of sessions on YARN can be reduced.
+livy.rsc.jars = local://<%= node['livy']['base_dir'] %>/rsc-jars/livy-api.jar,local://<%= node['livy']['base_dir'] %>/rsc-jars/livy-rsc.jar,local://<%= node['livy']['base_dir'] %>/rsc-jars/netty-all.jar
+
+# Comma-separated list of Livy REPL jars. By default Livy will upload jars from its installation
+# directory every time a session is started. By caching these files in HDFS, for example, startup
+# time of sessions on YARN can be reduced.
+livy.repl.jars = local://<%= node['livy']['base_dir'] %>repl_2.11-jars/commons-codec.jar,local://<%= node['livy']['base_dir'] %>/repl_2.11-jars/livy-core.jar,local://<%= node['livy']['base_dir'] %>/repl_2.11-jars/livy-repl.jar
+
+# Comma-separated list of Livy Datanucleus jars. By default Livy will upload jars from its installation
+# directory every time a session is started. By caching these files in HDFS, for example, startup
+# time of sessions on YARN can be reduced.
+livy.datanucleus.jars = local://<%= node['hadoop_spark']['base_dir'] %>/jars/datanucleus-api.jar,local://<%= node['hadoop_spark']['base_dir'] %>/jars/datanucleus-core.jar
+,local://<%= node['hadoop_spark']['base_dir'] %>/jars/datanucleus-rdbms.jar
+
+# Location of PySpark archives. By default Livy will upload the file from SPARK_HOME, but
+# by caching the file in HDFS, startup time of PySpark sessions on YARN can be reduced.
+livy.rsc.pyspark.archives = local://<%= node['hadoop_spark']['base_dir'] %>/python/lib/pyspark.zip,local://<%= node['hadoop_spark']['base_dir'] %>/python/lib/py4j-src.zip
+
+# Location of the SparkR package. By default Livy will upload the file from SPARK_HOME, but
+# by caching the file in HDFS, startup time of R sessions on YARN can be reduced.
+livy.rsc.sparkr.package = local://<%= node['hadoop_spark']['base_dir'] %>/R/lib/sparkr.zip
+
+
+# Comma-separated list of Livy RSC jars. By default Livy will upload jars from its installation
+# directory every time a session is started. By caching these files in HDFS, for example, startup
+# time of sessions on YARN can be reduced.
 #livy.jars = hdfs://<%= @nn_endpoint %>/<%= node['hops']['hdfs']['user_home'] %>/<%= node['livy']['user'] %>/apache-livy/rsc-jars
 
 # Comma-separated list of Livy REPL jars. By default Livy will upload jars from its installation


### PR DESCRIPTION
Speed up YARN job submission by using local binaries
instead of binaries on Hops-FS.